### PR TITLE
Whitelist all files to get real test coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Currently tests are not covering all the code, but coverage shows 99%. This patch whitelists everything in `src` directory, in order get real value.
