### PR TITLE
Pass path part to FastRoute dispatcher

### DIFF
--- a/src/Middleware/FastRouteMiddleware.php
+++ b/src/Middleware/FastRouteMiddleware.php
@@ -40,7 +40,10 @@ class FastRouteMiddleware implements MiddlewareInterface
      */
     public function execute(Harmony $harmony)
     {
-        $routeInfo = $this->dispatcher->dispatch($harmony->getRequest()->getMethod(), $harmony->getRequest()->getUri());
+        $routeInfo = $this->dispatcher->dispatch(
+            $harmony->getRequest()->getMethod(),
+            $harmony->getRequest()->getUri()->getPath()
+        );
 
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:


### PR DESCRIPTION
Currently `FastRouteMiddleware` passes `UriInterface` to `FastRoute\Dispatcher::dispatch` method, while it accepts a string, representing path part of the URI.
