### PR TITLE
SapiEmitter

### DIFF
--- a/src/Middleware/HttpHandlerRunnerMiddleware
+++ b/src/Middleware/HttpHandlerRunnerMiddleware
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace WoohooLabs\Harmony\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
+use Zend\HttpHandlerRunner\Emitter\SapiEmitter;
+
+class HttpHandlerRunnerMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var EmitterInterface
+     */
+    protected $emitter;
+    /**
+     * @var bool
+     */
+    protected $checkOutputStart;
+    public function __construct(EmitterInterface $emitter = null, bool $checkOutputStart = false)
+    {
+        $this->emitter = $emitter ?? new SapiEmitter();
+        $this->checkOutputStart = $checkOutputStart;
+    }
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+        if ($this->checkOutputStart === false || headers_sent() === false) {
+            $this->emitter->emit($response);
+        }
+        return $response;
+    }
+    public function getEmitter(): EmitterInterface
+    {
+        return $this->emitter;
+    }
+    public function setEmitter(EmitterInterface $emitter): void
+    {
+        $this->emitter = $emitter;
+    }
+    public function isOutputStartChecked(): bool
+    {
+        return $this->checkOutputStart;
+    }
+    public function setCheckOutputStart(bool $checkOutputStart): void
+    {
+        $this->checkOutputStart = $checkOutputStart;
+    }
+}


### PR DESCRIPTION
Diactoros deprecated SapiEmitter in 1.8. But since it's such a widely used package, I suggest having this and the Diactoros middlewares for at least a little while.