### PR TITLE
Fix issue with middleware after conditional

### DIFF
--- a/src/Harmony.php
+++ b/src/Harmony.php
@@ -88,12 +88,15 @@ class Harmony implements RequestHandlerInterface
         ]);
     }
 
-    protected function add(array $middleware): Harmony
+    /**
+     * @param array<string, mixed> $middlewareArray
+     */
+    protected function add(array $middlewareArray): Harmony
     {
         if ($this->injectNewMiddlewarePosition === null) {
-            $this->middleware[] = $middleware;
+            $this->middleware[] = $middlewareArray;
         } else {
-            array_splice($this->middleware, $this->injectNewMiddlewarePosition, 0, [$middleware]);
+            array_splice($this->middleware, $this->injectNewMiddlewarePosition, 0, [$middlewareArray]);
         }
 
         return $this;

--- a/src/Harmony.php
+++ b/src/Harmony.php
@@ -11,6 +11,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use WoohooLabs\Harmony\Condition\ConditionInterface;
 
 use function array_key_exists;
+use function array_splice;
 
 class Harmony implements RequestHandlerInterface
 {
@@ -87,7 +88,7 @@ class Harmony implements RequestHandlerInterface
         ]);
     }
 
-    protected function add($middleware)
+    protected function add(array $middleware): Harmony
     {
         if ($this->injectNewMiddlewarePosition === null) {
             $this->middleware[] = $middleware;

--- a/tests/HarmonyTest.php
+++ b/tests/HarmonyTest.php
@@ -185,6 +185,29 @@ class HarmonyTest extends TestCase
         $this->assertFalse($middleware->isInvoked());
     }
 
+    /**
+     * @test
+     */
+    public function runMiddlewareAfterConditionalMiddleware(): void
+    {
+        $middlewareCond = new SpyMiddleware();
+        $middlewareSecond = new SpyMiddleware();
+
+        $harmony = $this->createHarmony();
+        $harmony->addCondition(
+            new StubCondition(true),
+            static function (Harmony $harmony) use ($middlewareCond): void {
+                $harmony->addMiddleware($middlewareCond);
+            }
+        );
+        $harmony->addMiddleware($middlewareSecond);
+
+        $harmony->run();
+
+        $this->assertTrue($middlewareCond->isInvoked());
+        $this->assertTrue($middlewareSecond->isInvoked());
+    }
+
     protected function createHarmony(): Harmony
     {
         return new Harmony(new DummyServerRequest(), new DummyResponse());


### PR DESCRIPTION
If you add middleware after adding a condtional, nothing in the middleware in the queue is executed after the conditional. This fixes this issue.